### PR TITLE
docs: add post-mvp backlog

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,6 +7,10 @@ Potential follow-ups after the MVP ships. Keep scope small and prioritize by imp
 - Proposal templates for common actions (recurring transfers, adapter changes)
 - Treasury analytics: inflow/outflow charts and balance history
 
+## Prioritization approach
+- Re-rank monthly using impact vs. effort; keep the top 3 items unblocked.
+- Use small spikes to de-risk adapter registry changes before committing to builds.
+
 ## Medium impact
 - Multisig-style execute fallback for stuck proposals
 - Adapter registry UI and on-chain hash verification surface


### PR DESCRIPTION
- Capture a scoped backlog with high/medium/low items plus a lightweight prioritization cadence