### PR TITLE
fix: generalize treasury authorization

### DIFF
--- a/contracts/dao-treasury.clar
+++ b/contracts/dao-treasury.clar
@@ -16,6 +16,9 @@
   (or (is-eq caller DAO_CORE) (default-to false (map-get? allowed-invokers caller)))
 )
 
+(define-read-only (is-authorized (caller principal))
+  (ok (is-allowed-caller caller)))
+
 (define-public (execute-stx-transfer (amount uint) (recipient principal))
   (begin
     (asserts! (is-allowed-caller contract-caller) (err ERR_UNAUTHORIZED))


### PR DESCRIPTION
## Summary
Replaces the strict `DAO_CORE` check with a whitelist system, allowing the Adapter (and future contracts) to execute transfers when authorized.

## Changes
- Added `allowed-invokers` map and `set-allowed-invoker` function.
- Updated `execute-stx-transfer` and `execute-ft-transfer` to check the whitelist.
- Added `is-authorized` helper for visibility.

## Testing
- Existing tests should pass once the adapter is authorized (in future PRs or test setup).