### PR TITLE
feat(frontend): add FT transfer support to proposal form

### DIFF
--- a/frontend/components/create-proposal-form.tsx
+++ b/frontend/components/create-proposal-form.tsx
@@ -3,18 +3,45 @@
 import { useState } from "react";
 import { useWallet } from "@/components/wallet-provider";
 
+export type TransferKind = "stx-transfer" | "ft-transfer";
+
+export interface ProposalFormData {
+  kind: TransferKind;
+  amount: string;
+  recipient: string;
+  token?: string;
+  memo?: string;
+}
+
 export function CreateProposalForm({
   onSubmit,
 }: {
-  onSubmit: (data: { amount: string; recipient: string }) => void;
+  onSubmit: (data: ProposalFormData) => void;
 }) {
   const { address } = useWallet();
+  const [kind, setKind] = useState<TransferKind>("stx-transfer");
   const [amount, setAmount] = useState("");
   const [recipient, setRecipient] = useState("");
+  const [token, setToken] = useState("");
+  const [memo, setMemo] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ amount, recipient });
+    
+    const data: ProposalFormData = {
+      kind,
+      amount,
+      recipient,
+    };
+    
+    if (kind === "ft-transfer") {
+      data.token = token;
+      if (memo.trim()) {
+        data.memo = memo;
+      }
+    }
+    
+    onSubmit(data);
   };
 
   if (!address) {
@@ -27,6 +54,38 @@ export function CreateProposalForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* Transfer Type Selector */}
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-white/70">
+          Transfer Type
+        </label>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={() => setKind("stx-transfer")}
+            className={`flex-1 rounded-xl border py-3 font-medium transition ${
+              kind === "stx-transfer"
+                ? "border-emerald-400/50 bg-emerald-500/10 text-emerald-400"
+                : "border-white/10 bg-white/5 text-white/60 hover:bg-white/10"
+            }`}
+          >
+            STX Transfer
+          </button>
+          <button
+            type="button"
+            onClick={() => setKind("ft-transfer")}
+            className={`flex-1 rounded-xl border py-3 font-medium transition ${
+              kind === "ft-transfer"
+                ? "border-purple-400/50 bg-purple-500/10 text-purple-400"
+                : "border-white/10 bg-white/5 text-white/60 hover:bg-white/10"
+            }`}
+          >
+            Token Transfer
+          </button>
+        </div>
+      </div>
+
+      {/* Recipient Address */}
       <div className="space-y-2">
         <label htmlFor="recipient" className="text-sm font-medium text-white/70">
           Recipient Address
@@ -36,15 +95,37 @@ export function CreateProposalForm({
           type="text"
           value={recipient}
           onChange={(e) => setRecipient(e.target.value)}
-          placeholder="ST..."
+          placeholder="ST... or SP..."
           className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-white/20 focus:border-emerald-400/50 focus:outline-none focus:ring-1 focus:ring-emerald-400/50"
           required
         />
       </div>
 
+      {/* Token Contract (FT only) */}
+      {kind === "ft-transfer" && (
+        <div className="space-y-2">
+          <label htmlFor="token" className="text-sm font-medium text-white/70">
+            Token Contract
+          </label>
+          <input
+            id="token"
+            type="text"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="ST...::token-name"
+            className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-white/20 focus:border-purple-400/50 focus:outline-none focus:ring-1 focus:ring-purple-400/50"
+            required
+          />
+          <p className="text-xs text-white/40">
+            Full contract identifier (e.g., ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.my-token)
+          </p>
+        </div>
+      )}
+
+      {/* Amount */}
       <div className="space-y-2">
         <label htmlFor="amount" className="text-sm font-medium text-white/70">
-          Amount (uSTX)
+          Amount {kind === "stx-transfer" ? "(uSTX)" : "(smallest unit)"}
         </label>
         <input
           id="amount"
@@ -58,11 +139,36 @@ export function CreateProposalForm({
         />
       </div>
 
+      {/* Memo (FT only) */}
+      {kind === "ft-transfer" && (
+        <div className="space-y-2">
+          <label htmlFor="memo" className="text-sm font-medium text-white/70">
+            Memo (optional)
+          </label>
+          <input
+            id="memo"
+            type="text"
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            placeholder="Transfer memo..."
+            maxLength={34}
+            className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder-white/20 focus:border-purple-400/50 focus:outline-none focus:ring-1 focus:ring-purple-400/50"
+          />
+          <p className="text-xs text-white/40">
+            Max 34 characters
+          </p>
+        </div>
+      )}
+
       <button
         type="submit"
-        className="w-full rounded-xl bg-emerald-500 py-4 font-medium text-white hover:bg-emerald-600 transition"
+        className={`w-full rounded-xl py-4 font-medium text-white transition ${
+          kind === "stx-transfer"
+            ? "bg-emerald-500 hover:bg-emerald-600"
+            : "bg-purple-500 hover:bg-purple-600"
+        }`}
       >
-        Submit Proposal
+        Submit {kind === "stx-transfer" ? "STX" : "Token"} Transfer Proposal
       </button>
     </form>
   );


### PR DESCRIPTION
## Summary
- Add transfer type selector to switch between STX and fungible token transfers
- Add token contract input field for FT transfers
- Add optional memo field for FT transfers (max 34 chars)
- Export typed `ProposalFormData` interface

## Changes
The form now supports creating proposals for both:
- **STX transfers**: Native Stacks token transfers
- **FT transfers**: SIP-010 fungible token transfers

The UI adapts based on selected transfer type with visual distinction.

## Usage
```tsx
import { CreateProposalForm, ProposalFormData } from "@/components/create-proposal-form";

function handleSubmit(data: ProposalFormData) {
  // data.kind: "stx-transfer" | "ft-transfer"
  // data.amount: string
  // data.recipient: string
  // data.token?: string (for FT)
  // data.memo?: string (for FT)
}
```